### PR TITLE
support docker-compose.override.yml for local environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ pimple.json
 
 # Docker
 global/.env
+docker-compose.override.yml

--- a/global/docker-compose.yml
+++ b/global/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '3.4'
 services:
   dns-external:
     image: 'andyshinn/dnsmasq:latest'

--- a/src/Commands/GlobalDockerCommand.php
+++ b/src/Commands/GlobalDockerCommand.php
@@ -13,7 +13,7 @@ class GlobalDockerCommand extends Sq1Command {
 	 */
 	public function globalStart() {
 		$this->taskDockerComposeUp()
-		     ->file( self::COMPOSE_CONFIG )
+		     ->files( $this->global_compose_files() )
 		     ->projectName( self::PROJECT_NAME )
 		     ->detachedMode()
 		     ->run();
@@ -26,7 +26,7 @@ class GlobalDockerCommand extends Sq1Command {
 	 */
 	public function globalStop() {
 		$this->taskDockerComposeDown()
-		     ->file( self::COMPOSE_CONFIG )
+		     ->files( $this->global_compose_files() )
 		     ->projectName( self::PROJECT_NAME )
 		     ->run();
 	}
@@ -38,7 +38,7 @@ class GlobalDockerCommand extends Sq1Command {
 	 */
 	public function globalRestart() {
 		$this->taskDockerComposeRestart()
-		     ->file( self::COMPOSE_CONFIG )
+		     ->files( $this->global_compose_files() )
 		     ->projectName( self::PROJECT_NAME )
 		     ->run();
 	}

--- a/src/Commands/LocalDockerCommand.php
+++ b/src/Commands/LocalDockerCommand.php
@@ -43,7 +43,7 @@ class LocalDockerCommand extends GlobalDockerCommand {
 
 		// Start the local project
 		$this->taskDockerComposeUp()
-		     ->file( $config['compose'] )
+		     ->files( $config['compose'] )
 		     ->projectName( $config['name'] )
 		     ->detachedMode()
 		     ->forceRecreate()
@@ -63,7 +63,7 @@ class LocalDockerCommand extends GlobalDockerCommand {
 		$config = $this->getLocalDockerConfig();
 
 		$this->taskDockerComposeDown()
-		     ->file( $config['compose'] )
+		     ->files( $config['compose'] )
 		     ->projectName( $config['name'] )
 		     ->run();
 	}

--- a/src/Commands/Sq1Command.php
+++ b/src/Commands/Sq1Command.php
@@ -20,12 +20,16 @@ abstract class Sq1Command extends \Robo\Tasks {
 	/**
 	 * The root path of the script
 	 */
-	CONST SCRIPT_PATH = __DIR__ . '/../../';
+	const SCRIPT_PATH = __DIR__ . '/../../';
 
 	/**
 	 * The path to the docker-compose.yml file
 	 */
-	CONST COMPOSE_CONFIG = self::SCRIPT_PATH . 'global/docker-compose.yml';
+	const COMPOSE_CONFIG = self::SCRIPT_PATH . 'global/docker-compose.yml';
+	/**
+	 * The path to the docker-compose.override.yml file
+	 */
+	const COMPOSE_OVERRIDE = self::SCRIPT_PATH . 'global/docker-compose.override.yml';
 
 	/**
 	 * The docker working directory, e.g. /application/www
@@ -63,11 +67,18 @@ abstract class Sq1Command extends \Robo\Tasks {
 		$config = $this->getLocalDockerConfig();
 
 		$this->taskDockerComposeExecute()
-		     ->file( $config['compose'] )
+		     ->files( $config['compose'] )
 		     ->projectName( $config['name'] )
 		     ->setContainer( 'php-fpm' )
 		     ->exec( sprintf( 'composer %s -d %s', trim( $composerCommand ), $this->dockerWorkdir ) )
 		     ->run();
+	}
+
+	protected function global_compose_files(): array {
+		return array_filter( [
+			self::COMPOSE_CONFIG,
+			file_exists( self::COMPOSE_OVERRIDE ) ? self::COMPOSE_OVERRIDE: ''
+		] );
 	}
 
 }

--- a/src/Traits/LocalAwareTrait.php
+++ b/src/Traits/LocalAwareTrait.php
@@ -35,7 +35,7 @@ trait LocalAwareTrait {
 
 				if ( is_file( dirname( getcwd(), $count ) . '/build-process.php' ) ) {
 					$docker_dir     = dirname( getcwd(), $count ) . '/dev/docker';
-					$compose_config = realpath( $docker_dir . '/docker-compose.yml' );
+					$compose_config = [ realpath( $docker_dir . '/docker-compose.yml' ), realpath( $docker_dir . '/docker-compose.override.yml' ) ];
 					$project_name   = realpath( $docker_dir . '/.projectID' );
 
 					return $this->getConfig( $docker_dir, $compose_config, $project_name );
@@ -44,7 +44,7 @@ trait LocalAwareTrait {
 
 		} else {
 			$docker_dir     = dirname( $file ) . '/dev/docker';
-			$compose_config = realpath( $docker_dir . '/docker-compose.yml' );
+			$compose_config = [ realpath( $docker_dir . '/docker-compose.yml' ), realpath( $docker_dir . '/docker-compose.override.yml' ) ];
 			$project_name   = realpath( $docker_dir . '/.projectID' );
 
 			return $this->getConfig( $docker_dir, $compose_config, $project_name );
@@ -56,17 +56,17 @@ trait LocalAwareTrait {
 	/**
 	 * Returns the current project's sq1 config.
 	 *
-	 * @param  string  $docker_dir The path to the docker directory
-	 * @param  string  $compose_config The path to the docker-compose.yml file
-	 * @param  string  $project_name The project's name, as used by docker-compose
+	 * @param  string    $docker_dir The path to the docker directory
+	 * @param  string[]  $compose_config The path to the docker-compose.yml docker-compose.override.yml files
+	 * @param  string    $project_name The project's name, as used by docker-compose
 	 *
 	 * @return array
 	 */
-	private function getConfig( string $docker_dir, string $compose_config, string $project_name ): array {
+	private function getConfig( string $docker_dir, array $compose_config, string $project_name ): array {
 		return [
 			'name'       => trim( file_get_contents( $project_name ) ),
 			'docker_dir' => $docker_dir,
-			'compose'    => $compose_config,
+			'compose'    => array_filter( $compose_config, 'file_exists' ),
 		];
 	}
 


### PR DESCRIPTION
I override a few values in `docker-compose.yml` to run locally. We should support the standard behavior of loading a `docker-compose.override.yml` if it exists.