### PR TITLE
Updates certificate days to match current requirements

### DIFF
--- a/global/cert.sh
+++ b/global/cert.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
 if [ $# -lt 1 ]; then
-  echo 1>&2 "Usage: $0 domain.name"
+  echo 1>&2 "Usage: $0 domain.name [days to expiration default=825]"
   exit 2
 fi
 
 DOMAIN=$1
+DAYS=${2:-825}
 SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd );
 
 cd "$SCRIPTDIR";
@@ -13,7 +14,7 @@ cd "$SCRIPTDIR";
 if [ ! -f "${SCRIPTDIR}/certs/tribeCA.key" ]; then
 	echo "Generating certificate authority"
 
-	openssl req -x509 -new -nodes -sha256 -newkey rsa:4096 -days 3650 \
+	openssl req -x509 -new -nodes -sha256 -newkey rsa:4096 -days ${DAYS} \
 		-keyout "${SCRIPTDIR}/certs/tribeCA.key" \
 		-out "${SCRIPTDIR}/certs/tribeCA.pem" \
 		-subj "/C=US/ST=California/L=Santa Cruz/O=Modern Tribe/OU=Dev/CN=tri.be";
@@ -25,7 +26,7 @@ fi;
 
 echo "Generating SSL certificate for $DOMAIN";
 
-openssl req -new -nodes -sha256 -newkey rsa:4096 -days 3650 \
+openssl req -new -nodes -sha256 -newkey rsa:4096 -days ${DAYS} \
 	-keyout "${SCRIPTDIR}/certs/${DOMAIN}.key" \
 	-out "${SCRIPTDIR}/certs/${DOMAIN}.csr" \
 	-subj "/C=US/ST=California/L=Santa Cruz/O=Modern Tribe/OU=Dev/CN=${DOMAIN}";
@@ -40,7 +41,7 @@ cat > "${SCRIPTDIR}/certs/${DOMAIN}.ext" <<-EOF
 	DNS.2 = *.${DOMAIN}
 EOF
 
-openssl x509 -req -days 3650 -sha256 \
+openssl x509 -req -days ${DAYS} -sha256 \
 	-in "${SCRIPTDIR}/certs/${DOMAIN}.csr" \
 	-CA "${SCRIPTDIR}/certs/tribeCA.pem" \
 	-CAkey "${SCRIPTDIR}/certs/tribeCA.key" \


### PR DESCRIPTION
Updates the number of days a certificate can last to the new maximum of 825. 

This is the same pr I submitted to squareone, just wanted to make sure the changes didn't get lost as we transition over.