### PR TITLE
Refactor local detection

### DIFF
--- a/app/Services/Docker/Local/Config.php
+++ b/app/Services/Docker/Local/Config.php
@@ -88,6 +88,11 @@ class Config {
 
             while ( true ) {
 
+                // We've reached the root of the operating system, bail out
+                if ( '/' === $this->path ) {
+                    break;
+                }
+
                 // Check if we're in a submodule first
                 $response = $this->runner->with( [
                     'path' => $this->path,
@@ -99,13 +104,14 @@ class Config {
                     ] )->run( 'git -C {{ $path }} rev-parse --show-toplevel' );
                 }
 
+                // Can't find the project root using git, check existing path or use the current working directory
                 if ( ! $response->ok() ) {
-                    throw new RuntimeException( 'Unable to find project root. Are you sure this is a SquareOne Project?' );
+                    $response = $this->path ? $this->path : getcwd();
                 }
 
                 $response = trim( (string) $response );
 
-                // If these files exist, this is probably a SquareOne project.
+                // If these files exist, this is probably a SquareOne project
                 $squareOneFiles = [
                     "{$response}/dev/docker/docker-compose.yml",
                     "{$response}/squareone.yml",
@@ -113,7 +119,7 @@ class Config {
 
                 $squareOneFiles = array_filter( $squareOneFiles, 'file_exists' );
 
-                // Check the directory above and continue the loop.
+                // Check the directory above and continue the loop
                 if ( empty( $squareOneFiles ) ) {
                     $this->path = dirname( $response );
                     continue;
@@ -124,6 +130,11 @@ class Config {
                 break;
             }
 
+        }
+
+        // We couldn't find a SquareOne project
+        if ( empty( $this->projectRoot ) ) {
+            throw new RuntimeException( 'Unable to find project root. Are you sure this is a SquareOne Project?' );
         }
 
         return $this->projectRoot;

--- a/app/Services/Docker/Local/Config.php
+++ b/app/Services/Docker/Local/Config.php
@@ -93,39 +93,23 @@ class Config {
                     break;
                 }
 
-                // Check if we're in a submodule first
-                $response = $this->runner->with( [
-                    'path' => $this->path,
-                ] )->run( 'git -C {{ $path }} rev-parse --show-superproject-working-tree' );
+                $path = $this->path ? $this->path : getcwd();
 
-                if ( empty( trim( (string) $response ) ) ) {
-                    $response = $this->runner->with( [
-                        'path' => $this->path,
-                    ] )->run( 'git -C {{ $path }} rev-parse --show-toplevel' );
-                }
-
-                // Can't find the project root using git, check existing path or use the current working directory
-                if ( ! $response->ok() ) {
-                    $response = $this->path ? $this->path : getcwd();
-                }
-
-                $response = trim( (string) $response );
-
-                // If these files exist, this is probably a SquareOne project
+                // If these either of these files exist, this is probably a SquareOne project
                 $squareOneFiles = [
-                    "{$response}/dev/docker/docker-compose.yml",
-                    "{$response}/squareone.yml",
+                    "{$path}/dev/docker/docker-compose.yml",
+                    "{$path}/squareone.yml",
                 ];
 
                 $squareOneFiles = array_filter( $squareOneFiles, 'file_exists' );
 
                 // Check the directory above and continue the loop
                 if ( empty( $squareOneFiles ) ) {
-                    $this->path = dirname( $response );
+                    $this->path = dirname( $path );
                     continue;
                 }
 
-                $this->projectRoot = trim( $response );
+                $this->projectRoot = trim( $path );
 
                 break;
             }

--- a/squareone.autocompletion
+++ b/squareone.autocompletion
@@ -70,11 +70,11 @@ _so.phar()
             ;;
 
             start)
-            opts="${opts} --browser --path"
+            opts="${opts} --browser --path --remove-orphans"
             ;;
 
             stop)
-            opts="${opts} "
+            opts="${opts} --remove-orphans"
             ;;
 
             test)

--- a/tests/Unit/Services/Docker/Local/ConfigExceptionTest.php
+++ b/tests/Unit/Services/Docker/Local/ConfigExceptionTest.php
@@ -13,7 +13,6 @@ use Illuminate\Support\Facades\Storage;
 class ConfigExceptionTest extends TestCase {
 
     private $runner;
-    private $response;
 
     protected function setUp(): void {
         parent::setUp();
@@ -22,7 +21,6 @@ class ConfigExceptionTest extends TestCase {
         error_reporting( 0 );
 
         $this->runner   = $this->mock( CommandRunner::class );
-        $this->response = $this->mock( Response::class );
     }
 
     public function test_it_throws_exception_on_invalid_project_root() {
@@ -32,16 +30,6 @@ class ConfigExceptionTest extends TestCase {
         Storage::disk( 'local' )->put( 'tests/squareone/dev/docker/docker-compose.yml', '' );
 
         $this->runner->shouldReceive( 'with' )->with( [ 'path' => '' ] )->andReturnSelf();
-        $this->runner->shouldReceive( 'run' )
-                     ->with( 'git -C {{ $path }} rev-parse --show-superproject-working-tree' )
-                     ->andReturn( $this->response );
-        $this->runner->shouldReceive( 'run' )
-                     ->with( 'git -C {{ $path }} rev-parse --show-toplevel' )
-                     ->andReturn( $this->response );
-
-        // Submodule returned nothing
-        $this->response->shouldReceive( '__toString' )->once()->andReturn( '' );
-        $this->response->shouldReceive( 'ok' )->andReturnFalse();
 
         // Mock we already hit the operating system's root folder
         PHPMockery::mock( 'App\Services\Docker\Local', 'getcwd' )->andReturn( '/' );

--- a/tests/Unit/Services/Docker/Local/ConfigTest.php
+++ b/tests/Unit/Services/Docker/Local/ConfigTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Services\Docker\Local;
 
 use Tests\TestCase;
 use App\Runners\CommandRunner;
+use phpmock\mockery\PHPMockery;
 use TitasGailius\Terminal\Response;
 use App\Services\Docker\Local\Config;
 use Illuminate\Support\Facades\Storage;
@@ -11,7 +12,6 @@ use Illuminate\Support\Facades\Storage;
 class ConfigTest extends TestCase {
 
     protected $runner;
-    protected $response;
 
     protected function setUp(): void {
         parent::setUp();
@@ -21,22 +21,12 @@ class ConfigTest extends TestCase {
         // Prevent Mockery from erroring out on Response::__call
         error_reporting( 0 );
 
-        $this->response = $this->mock( Response::class );
-
         $this->runner = $this->mock( CommandRunner::class );
 
         $this->runner->shouldReceive( 'with' )
                      ->with( [
                          'path' => '',
                      ] )->andReturnSelf();
-
-        $this->runner->shouldReceive( 'run' )
-                     ->with( 'git -C {{ $path }} rev-parse --show-superproject-working-tree' )
-                     ->andReturn( $this->response );
-
-        $this->runner->shouldReceive( 'run' )
-                     ->with( 'git -C {{ $path }} rev-parse --show-toplevel' )
-                     ->andReturn( $this->response );
     }
 
     public function test_it_can_set_a_path() {
@@ -44,19 +34,6 @@ class ConfigTest extends TestCase {
                      ->with( [
                          'path' => storage_path( 'tests/squareone' ),
                      ] )->andReturnSelf();
-
-        // No submodule found
-        $this->response->shouldReceive( '__toString' )
-                       ->once()
-                       ->andReturn( '' );
-
-        $this->response->shouldReceive( 'ok' )
-                       ->once()
-                       ->andReturnSelf();
-
-        $this->response->shouldReceive( '__toString' )
-                       ->once()
-                       ->andReturn( storage_path( 'tests/squareone' ) );
 
         $config = new Config( $this->runner );
 
@@ -66,103 +43,19 @@ class ConfigTest extends TestCase {
     }
 
     public function test_it_gets_a_project_root() {
-        // No submodule found
-        $this->response->shouldReceive( '__toString' )
-                       ->once()
-                       ->andReturn( '' );
-
-        $this->response->shouldReceive( 'ok' )
-                       ->once()
-                       ->andReturnSelf();
-
-        $this->response->shouldReceive( '__toString' )
-                       ->once()
-                       ->andReturn( storage_path( 'tests/squareone' ) );
+        // Mock getcwd() found our tests storage path
+        PHPMockery::mock( 'App\Services\Docker\Local', 'getcwd' )->andReturn( storage_path( 'tests/squareone' ) );
 
         $config = new Config( $this->runner );
 
         $root = $config->getProjectRoot();
 
         $this->assertSame( storage_path( 'tests/squareone' ), $root );
-    }
-
-    public function test_it_gets_a_project_root_for_submodule() {
-        // Found via sub module
-        $this->response->shouldReceive( '__toString' )
-                       ->once()
-                       ->andReturn( storage_path( 'tests/squareone' ) );
-
-        $this->response->shouldReceive( 'ok' )
-                       ->once()
-                       ->andReturnSelf();
-
-        $this->response->shouldReceive( '__toString' )
-                       ->once()
-                       ->andReturn( storage_path( 'tests/squareone' ) );
-
-        $config = new Config( $this->runner );
-
-        $root = $config->getProjectRoot();
-
-        $this->assertSame( storage_path( 'tests/squareone' ), $root );
-    }
-
-    public function test_it_gets_a_project_root_in_sub_git_repo() {
-        Storage::disk( 'local' )->put( 'tests/squareone_with_sub_repo/dev/docker/docker-compose.yml', '' );
-        Storage::disk( 'local' )->makeDirectory( 'tests/squareone_with_sub_repo/sub_repo' );
-
-        // No submodule found
-        $this->response->shouldReceive( '__toString' )
-                       ->once()
-                       ->andReturn( '' );
-
-        $this->response->shouldReceive( 'ok' )
-                       ->once()
-                       ->andReturnSelf();
-
-        $this->response->shouldReceive( '__toString' )
-                       ->once()
-                       ->andReturn( storage_path( 'tests/squareone_with_sub_repo/sub_repo' ) );
-
-        // With no dev/docker/docker-compose.yml found in the above directory, expect the next loop
-        $this->runner->shouldReceive( 'with' )
-                     ->with( [
-                         'path' => storage_path( 'tests/squareone_with_sub_repo' ),
-                     ] )->andReturnSelf();
-
-        // No submodule found
-        $this->response->shouldReceive( '__toString' )
-                       ->once()
-                       ->andReturn( '' );
-
-        $this->response->shouldReceive( 'ok' )
-                       ->once()
-                       ->andReturnSelf();
-
-        $this->response->shouldReceive( '__toString' )
-                       ->once()
-                       ->andReturn( storage_path( 'tests/squareone_with_sub_repo' ) );
-
-        $config = new Config( $this->runner );
-
-        $root = $config->getProjectRoot();
-
-        $this->assertSame( storage_path( 'tests/squareone_with_sub_repo' ), $root );
     }
 
     public function test_it_finds_docker_compose_yml() {
-        // No submodule found
-        $this->response->shouldReceive( '__toString' )
-                       ->once()
-                       ->andReturn( '' );
-
-        $this->response->shouldReceive( 'ok' )
-                       ->once()
-                       ->andReturnSelf();
-
-        $this->response->shouldReceive( '__toString' )
-                       ->once()
-                       ->andReturn( storage_path( 'tests/squareone' ) );
+        // Mock getcwd() found our tests storage path
+        PHPMockery::mock( 'App\Services\Docker\Local', 'getcwd' )->andReturn( storage_path( 'tests/squareone' ) );
 
         $config = new Config( $this->runner );
 
@@ -172,20 +65,10 @@ class ConfigTest extends TestCase {
     }
 
     public function test_it_finds_docker_compose_override_yml() {
-        // No submodule found
-        $this->response->shouldReceive( '__toString' )
-                       ->once()
-                       ->andReturn( '' );
-
-        $this->response->shouldReceive( 'ok' )
-                       ->once()
-                       ->andReturnSelf();
-
-        $this->response->shouldReceive( '__toString' )
-                       ->once()
-                       ->andReturn( storage_path( 'tests/squareone' ) );
-
         Storage::disk( 'local' )->put( 'tests/squareone/dev/docker/docker-compose.override.yml', '' );
+
+        // Mock getcwd() found our tests storage path
+        PHPMockery::mock( 'App\Services\Docker\Local', 'getcwd' )->andReturn( storage_path( 'tests/squareone' ) );
 
         $config = new Config( $this->runner );
 
@@ -195,20 +78,10 @@ class ConfigTest extends TestCase {
     }
 
     public function test_it_gets_a_project_name() {
-        // No submodule found
-        $this->response->shouldReceive( '__toString' )
-                       ->once()
-                       ->andReturn( '' );
-
-        $this->response->shouldReceive( 'ok' )
-                       ->once()
-                       ->andReturnSelf();
-
-        $this->response->shouldReceive( '__toString' )
-                       ->once()
-                       ->andReturn( storage_path( 'tests/squareone' ) );
-
         Storage::disk( 'local' )->put( 'tests/squareone/dev/docker/.projectID', 'squareone' );
+
+        // Mock getcwd() found our tests storage path
+        PHPMockery::mock( 'App\Services\Docker\Local', 'getcwd' )->andReturn( storage_path( 'tests/squareone' ) );
 
         $config = new Config( $this->runner );
 
@@ -218,20 +91,10 @@ class ConfigTest extends TestCase {
     }
 
     public function test_it_gets_project_domain() {
-        // No submodule found
-        $this->response->shouldReceive( '__toString' )
-                       ->once()
-                       ->andReturn( '' );
-
-        $this->response->shouldReceive( 'ok' )
-                       ->once()
-                       ->andReturnSelf();
-
-        $this->response->shouldReceive( '__toString' )
-                       ->once()
-                       ->andReturn( storage_path( 'tests/squareone' ) );
-
         Storage::disk( 'local' )->put( 'tests/squareone/dev/docker/.projectID', 'squareone' );
+
+        // Mock getcwd() found our tests storage path
+        PHPMockery::mock( 'App\Services\Docker\Local', 'getcwd' )->andReturn( storage_path( 'tests/squareone' ) );
 
         $config = new Config( $this->runner );
 
@@ -245,20 +108,10 @@ class ConfigTest extends TestCase {
     }
 
     public function test_it_gets_project_url() {
-        // No submodule found
-        $this->response->shouldReceive( '__toString' )
-                       ->once()
-                       ->andReturn( '' );
-
-        $this->response->shouldReceive( 'ok' )
-                       ->once()
-                       ->andReturnSelf();
-
-        $this->response->shouldReceive( '__toString' )
-                       ->once()
-                       ->andReturn( storage_path( 'tests/squareone' ) );
-
         Storage::disk( 'local' )->put( 'tests/squareone/dev/docker/.projectID', 'squareone' );
+
+        // Mock getcwd() found our tests storage path
+        PHPMockery::mock( 'App\Services\Docker\Local', 'getcwd' )->andReturn( storage_path( 'tests/squareone' ) );
 
         $config = new Config( $this->runner );
 
@@ -272,20 +125,10 @@ class ConfigTest extends TestCase {
     }
 
     public function test_it_gets_composer_volume() {
-        // No submodule found
-        $this->response->shouldReceive( '__toString' )
-                       ->once()
-                       ->andReturn( '' );
-
-        $this->response->shouldReceive( 'ok' )
-                       ->once()
-                       ->andReturnSelf();
-
-        $this->response->shouldReceive( '__toString' )
-                       ->once()
-                       ->andReturn( storage_path( 'tests/squareone' ) );
-
         $config = new Config( $this->runner );
+
+        // Mock getcwd() found our tests storage path
+        PHPMockery::mock( 'App\Services\Docker\Local', 'getcwd' )->andReturn( storage_path( 'tests/squareone' ) );
 
         $root = $config->getComposerVolume();
 


### PR DESCRIPTION
I'm in need of running multiple SquareOne projects in a single repository and the git command to detect the current root obviously would not longer work. Implemented directory traversal instead.

Will go out in 3.0.1