### PR TITLE
Refactor how we enable DNS resolvers for different strategies

### DIFF
--- a/app/Services/Docker/Dns/Factory.php
+++ b/app/Services/Docker/Dns/Factory.php
@@ -68,10 +68,10 @@ class Factory {
     public function make( Collection $resolvers ): BaseSupport {
         if ( OperatingSystem::LINUX === $this->os->getFamily() ) {
             $resolvers->push(
-                new Dhcp( $this->runner, $this->filesystem ),
-                new SystemdResolved( $this->runner, $this->filesystem ),
+                new Openresolv( $this->runner, $this->filesystem, '/etc/resolv.conf.head' ),
                 new ResolvConf( $this->runner, $this->filesystem, '/etc/resolvconf/resolv.conf.d/head' ),
-                new Openresolv( $this->runner, $this->filesystem, '/etc/resolv.conf.head' )
+                new Dhcp( $this->runner, $this->filesystem ),
+                new SystemdResolved( $this->runner, $this->filesystem )
             );
 
             return new Linux( $resolvers );

--- a/app/Services/Docker/Dns/Resolvers/Openresolv.php
+++ b/app/Services/Docker/Dns/Resolvers/Openresolv.php
@@ -1,0 +1,56 @@
+<?php declare( strict_types=1 );
+
+namespace App\Services\Docker\Dns\Resolvers;
+
+use LaravelZero\Framework\Commands\Command;
+
+/**
+ * Set resolvers for systems using the resolvconf package.
+ *
+ * @see     https://packages.ubuntu.com/focal/resolvconf
+ *
+ * @package App\Services\Docker\Dns\Resolvers
+ */
+class Openresolv extends ResolvConf {
+
+    /**
+     * Check if openresolv's resolvconf binary is available.
+     *
+     * @see https://roy.marples.name/projects/openresolv/
+     *
+     * @return bool
+     */
+    public function supported(): bool {
+        $response = $this->runner->run( 'resolvconf --version' );
+
+        if ( $response->ok() ) {
+            if ( str_contains( (string) $response, 'openresolv' ) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Enable local nameservers for /etc/resolv.conf.
+     *
+     * @param   \LaravelZero\Framework\Commands\Command  $command
+     */
+    public function enable( Command $command ): void {
+        parent::enable( $command );
+
+        $command->task( '<comment>➜ Running sudo resolvconf -u</comment>', call_user_func( [
+            $this,
+            'writeResolvConf'
+        ] ) );
+    }
+
+    /**
+     * Write to /etc/resolv.conf
+     */
+    public function writeResolvConf(): void {
+        $this->runner->run( 'sudo resolvconf -u' )->throw();
+    }
+
+}

--- a/app/Services/Docker/Dns/Resolvers/Scutil.php
+++ b/app/Services/Docker/Dns/Resolvers/Scutil.php
@@ -1,0 +1,29 @@
+<?php declare( strict_types=1 );
+
+namespace App\Services\Docker\Dns\Resolvers;
+
+/**
+ * Set resolvers for MacOS
+ *
+ * @see     https://ss64.com/osx/scutil.html
+ *
+ * @package App\Services\Docker\Dns\Resolvers
+ */
+class Scutil extends ResolvConf {
+
+    /**
+     * Check if this OS supports scutil, which runs on MacOS.
+     *
+     * @return bool
+     */
+    public function supported(): bool {
+        $response = $this->runner->run( 'scutil --dns' );
+
+        if ( $response->ok() ) {
+            return true;
+        }
+
+        return false;
+    }
+
+}

--- a/tests/Unit/Services/Docker/Dns/FactoryTest.php
+++ b/tests/Unit/Services/Docker/Dns/FactoryTest.php
@@ -12,7 +12,9 @@ use App\Services\Docker\Dns\OsSupport\Linux;
 use App\Services\Docker\Dns\OsSupport\MacOs;
 use App\Services\Docker\Dns\OsSupport\NullOs;
 use App\Services\Docker\Dns\Resolvers\Dhcp;
+use App\Services\Docker\Dns\Resolvers\Scutil;
 use App\Services\Docker\Dns\Resolvers\ResolvConf;
+use App\Services\Docker\Dns\Resolvers\Openresolv;
 use App\Services\Docker\Dns\Resolvers\SystemdResolved;
 
 class FactoryTest extends TestCase {
@@ -42,17 +44,14 @@ class FactoryTest extends TestCase {
         $this->assertEmpty( $support->resolvers() );
     }
 
-    public function test_it_can_create_an_arch_resolver() {
-        $this->os->shouldReceive( 'getFamily' )->andReturn( 'Linux' );
-        $this->os->shouldReceive( 'getLinuxFlavor' )->andReturn( 'Arch' );
-
-        $factory = new Factory( $this->os, $this->runner, $this->filesystem  );
+    public function test_it_creates_linux_resolvers() {
+        $factory = new Factory( $this->os, $this->runner, $this->filesystem );
 
         $support = $factory->make( $this->collection );
 
         $this->assertInstanceOf( Linux::class, $support );
         $this->assertNotEmpty( $support->resolvers() );
-        $this->assertSame( 3, $this->collection->count() );
+        $this->assertSame( 4, $this->collection->count() );
 
         $this->assertTrue( $this->collection->contains( function ( $instance ) {
             return is_a( $instance, Dhcp::class );
@@ -65,34 +64,13 @@ class FactoryTest extends TestCase {
         $this->assertTrue( $this->collection->contains( function ( $instance ) {
             return is_a( $instance, ResolvConf::class );
         } ) );
-    }
-
-    public function test_it_can_create_a_debian_resolver() {
-        $this->os->shouldReceive( 'getFamily' )->andReturn( 'Linux' );
-        $this->os->shouldReceive( 'getLinuxFlavor' )->andReturn( 'Debian' );
-
-        $factory = new Factory( $this->os, $this->runner, $this->filesystem  );
-
-        $support = $factory->make( $this->collection );
-
-        $this->assertInstanceOf( Linux::class, $support );
-        $this->assertNotEmpty( $support->resolvers() );
-        $this->assertSame( 3, $this->collection->count() );
 
         $this->assertTrue( $this->collection->contains( function ( $instance ) {
-            return is_a( $instance, Dhcp::class );
-        } ) );
-
-        $this->assertTrue( $this->collection->contains( function ( $instance ) {
-            return is_a( $instance, SystemdResolved::class );
-        } ) );
-
-        $this->assertTrue( $this->collection->contains( function ( $instance ) {
-            return is_a( $instance, ResolvConf::class );
+            return is_a( $instance, Openresolv::class );
         } ) );
     }
 
-    public function test_it_can_create_an_macos_resolver() {
+    public function test_it_can_create_an_scutil_resolver() {
         $this->os->shouldReceive( 'getFamily' )->andReturn( 'Darwin' );
 
         $factory = new Factory( $this->os, $this->runner, $this->filesystem );
@@ -104,7 +82,7 @@ class FactoryTest extends TestCase {
         $this->assertSame( 1, $this->collection->count() );
 
         $this->assertTrue( $this->collection->contains( function ( $instance ) {
-            return is_a( $instance, ResolvConf::class );
+            return is_a( $instance, Scutil::class );
         } ) );
     }
 

--- a/tests/Unit/Services/Docker/Dns/Resolvers/ScutilTest.php
+++ b/tests/Unit/Services/Docker/Dns/Resolvers/ScutilTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Unit\Services\Docker\Dns\Resolvers;
+
+use Tests\TestCase;
+use App\Runners\CommandRunner;
+use Illuminate\Filesystem\Filesystem;
+use App\Services\Docker\Dns\Resolvers\Scutil;
+
+class ScutilTest extends TestCase {
+
+    private $runner;
+    private $filesystem;
+    private $file;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        $this->runner     = $this->mock( CommandRunner::class );
+        $this->filesystem = $this->mock( Filesystem::class );
+        $this->file       = storage_path( 'tests/resolv.conf.head' );
+    }
+
+
+    public function test_it_is_supported() {
+        $this->runner->shouldReceive( 'run' )
+                     ->with( 'scutil --dns' )
+                     ->once()
+                     ->andReturnSelf();
+
+        $this->runner->shouldReceive( 'ok' )
+                     ->once()
+                     ->andReturnTrue();
+
+        $resolver = new Scutil( $this->runner, $this->filesystem, $this->file );
+
+        $this->assertTrue( $resolver->supported() );
+    }
+
+    public function test_it_is_not_supported() {
+        $this->runner->shouldReceive( 'run' )
+                     ->with( 'scutil --dns' )
+                     ->once()
+                     ->andReturnSelf();
+
+        $this->runner->shouldReceive( 'ok' )
+                     ->once()
+                     ->andReturnFalse();
+
+        $resolver = new Scutil( $this->runner, $this->filesystem, $this->file );
+
+        $this->assertFalse( $resolver->supported() );
+    }
+}


### PR DESCRIPTION
Addresses https://github.com/moderntribe/square1-global-docker/issues/50 and adds better detection for different resolver strategies across Linux/MacOS in addition to making sure directories exist before trying to write files to them.