### PR TITLE
Feature/xdebug v3

### DIFF
--- a/app/Commands/BaseCommand.php
+++ b/app/Commands/BaseCommand.php
@@ -21,4 +21,9 @@ abstract class BaseCommand extends Command {
      */
     public const EXIT_ERROR = 1;
 
+    /**
+     * Environment variable to enable XDEBUG 3.0
+     */
+    public const XDEBUG_ENV = 'XDEBUG_SESSION=PHPSTORM';
+
 }

--- a/app/Commands/LocalDocker/Test.php
+++ b/app/Commands/LocalDocker/Test.php
@@ -63,9 +63,16 @@ class Test extends BaseLocalDocker {
             'exec',
             '--env',
             'COMPOSE_INTERACTIVE_NO_CLI=1',
-            '--env',
-            "PHP_IDE_CONFIG=serverName={$config->getProjectName()}.tribe",
         ];
+
+        if ( $this->option( 'xdebug' ) ) {
+          $params = array_merge( $params, [
+              '--env',
+              "PHP_IDE_CONFIG=serverName={$config->getProjectName()}.tribe",
+              '--env',
+              self::XDEBUG_ENV,
+          ] );
+        }
 
         if ( $this->option( 'notty' ) ) {
             $params = array_merge( $params, [ '-T' ] );
@@ -75,26 +82,12 @@ class Test extends BaseLocalDocker {
 
         $params = array_merge( $params, [ $container ] );
 
-        if ( $this->option( 'xdebug' ) ) {
-            $exec = [
-                'php',
-                '-dxdebug.remote_autostart=1',
-                '-dxdebug.remote_host=host.tribe',
-                '-dxdebug.remote_enable=1',
-                '/application/www/vendor/bin/codecept',
-                '-c',
-                "/application/www/dev/tests",
-            ];
-        } else {
-            $exec = [
-                'php',
-                '-dxdebug.remote_autostart=0',
-                '-dxdebug.remote_enable=0',
-                '/application/www/vendor/bin/codecept',
-                '-c',
-                '/application/www/dev/tests',
-            ];
-        }
+        $exec = [
+            'php',
+            '/application/www/vendor/bin/codecept',
+            '-c',
+            '/application/www/dev/tests',
+        ];
 
         chdir( $config->getDockerDir() );
 

--- a/app/Commands/LocalDocker/Wp.php
+++ b/app/Commands/LocalDocker/Wp.php
@@ -50,28 +50,19 @@ class Wp extends BaseLocalDocker {
         if ( $this->option( 'xdebug' ) ) {
             $env = [
                 '--env',
-                "PHP_IDE_CONFIG=serverName={$config->getProjectName()}.tribe",
-            ];
-
-            $exec = [
-                'php',
-                '-dxdebug.remote_autostart=1',
-                '-dxdebug.remote_host=host.tribe',
-                '-dxdebug.remote_enable=1',
-                '/usr/local/bin/wp',
-                '--allow-root',
+                self::XDEBUG_ENV,
             ];
         } else {
             $env = [
                 '--env',
                 'WP_CLI_PHP_ARGS',
             ];
-
-            $exec = [
-                '/usr/local/bin/wp',
-                '--allow-root',
-            ];
         }
+
+        $exec = [
+            '/usr/local/bin/wp',
+            '--allow-root',
+        ];
 
         $params = array_merge( $params, $env, [ 'php-fpm' ], $exec, $this->argument( 'args' ) );
 

--- a/app/Commands/LocalDocker/Wp.php
+++ b/app/Commands/LocalDocker/Wp.php
@@ -3,6 +3,8 @@
 namespace App\Commands\LocalDocker;
 
 use App\Commands\DockerCompose;
+use App\Services\XdebugValidator;
+use App\Traits\XdebugWarningTrait;
 use App\Services\Docker\Local\Config;
 use Illuminate\Support\Facades\Artisan;
 
@@ -12,6 +14,8 @@ use Illuminate\Support\Facades\Artisan;
  * @package App\Commands\LocalDocker
  */
 class Wp extends BaseLocalDocker {
+
+    use XdebugWarningTrait;
 
     /**
      * The signature of the command.
@@ -33,10 +37,11 @@ class Wp extends BaseLocalDocker {
      * Execute the console command.
      *
      * @param  \App\Services\Docker\Local\Config  $config
+     * @param  \App\Services\XdebugValidator      $xdebugValidator
      *
-     * @return int
+     * @return int|null
      */
-    public function handle( Config $config ) {
+    public function handle( Config $config, XdebugValidator $xdebugValidator ): ?int {
         $params = [
             '--project-name',
             $config->getProjectName(),
@@ -48,6 +53,13 @@ class Wp extends BaseLocalDocker {
         }
 
         if ( $this->option( 'xdebug' ) ) {
+
+            $phpIni = $config->getPhpIni();
+
+            if ( ! $xdebugValidator->valid( $phpIni ) ) {
+                $this->outdatedXdebugWarning( $phpIni );
+            }
+
             $env = [
                 '--env',
                 self::XDEBUG_ENV,

--- a/app/Services/Docker/Local/Config.php
+++ b/app/Services/Docker/Local/Config.php
@@ -134,6 +134,15 @@ class Config {
     }
 
     /**
+     * Get the path to the the docker php.ini file.
+     *
+     * @return string
+     */
+    public function getPhpIni(): string {
+        return "{$this->getDockerDir()}/php/php-ini-overrides.ini";
+    }
+
+    /**
      * Get the project's name.
      *
      * @return string

--- a/app/Services/XdebugValidator.php
+++ b/app/Services/XdebugValidator.php
@@ -1,0 +1,46 @@
+<?php declare( strict_types=1 );
+
+namespace App\Services;
+
+use App\Contracts\File;
+
+/**
+ * Validate Xdebug is correctly configured for a project.
+ *
+ * @package App\Services
+ */
+class XdebugValidator {
+
+    /**
+     * @var \App\Contracts\File
+     */
+    protected $file;
+
+    /**
+     * XdebugValidator constructor.
+     *
+     * @param  \App\Contracts\File  $file
+     */
+    public function __construct( File $file ) {
+        $this->file = $file;
+    }
+
+    /**
+     * Determine if a php.ini file contains xdebug v3.0+ configuration.
+     *
+     * @param  string  $phpIni The path to the project's php-ini-overrides.ini
+     *
+     * @return bool
+     */
+    public function valid( string $phpIni ): bool {
+        if ( ! $this->file->exists( $phpIni ) ) {
+            return true;
+        }
+
+        if ( $this->file->contains( $phpIni, 'xdebug.mode' ) ) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/app/Traits/XdebugWarningTrait.php
+++ b/app/Traits/XdebugWarningTrait.php
@@ -6,7 +6,7 @@ trait XdebugWarningTrait {
 
     protected function outdatedXdebugWarning( string $phpIni ): void {
         $this->warn( sprintf(
-            'This project\'s %s is not configured correctly for xdebug v3.0+. See %s for more information.',
+            'This project\'s %s is not configured correctly for xdebug v3.0+. See %s upgrade instructions.',
             $phpIni,
             'https://github.com/moderntribe/square-one/pull/695'
         ) );

--- a/app/Traits/XdebugWarningTrait.php
+++ b/app/Traits/XdebugWarningTrait.php
@@ -1,0 +1,14 @@
+<?php declare( strict_types=1 );
+
+namespace App\Traits;
+
+trait XdebugWarningTrait {
+
+    protected function outdatedXdebugWarning( string $phpIni ): void {
+        $this->warn( sprintf(
+            'This project\'s %s is not configured correctly for xdebug v3.0+. See %s for more information.',
+            $phpIni,
+            'https://github.com/moderntribe/square-one/pull/695'
+        ) );
+    }
+}

--- a/app/Traits/XdebugWarningTrait.php
+++ b/app/Traits/XdebugWarningTrait.php
@@ -4,6 +4,11 @@ namespace App\Traits;
 
 trait XdebugWarningTrait {
 
+    /**
+     * Display a warning in a Command if a user has an old configuration for Xdebug.
+     *
+     * @param  string  $phpIni The path to the project's docker php-ini-overrides.ini
+     */
     protected function outdatedXdebugWarning( string $phpIni ): void {
         $this->warn( sprintf(
             'This project\'s %s is not configured correctly for xdebug v3.0+. See %s upgrade instructions.',

--- a/tests/Feature/Commands/LocalDocker/TestTest.php
+++ b/tests/Feature/Commands/LocalDocker/TestTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Commands\LocalDocker;
 
+use App\Commands\BaseCommand;
 use App\Commands\DockerCompose;
 use App\Commands\LocalDocker\Test;
 use Illuminate\Support\Facades\Artisan;
@@ -18,12 +19,8 @@ class TestTest extends LocalDockerCommand {
             'exec',
             '--env',
             'COMPOSE_INTERACTIVE_NO_CLI=1',
-            '--env',
-            'PHP_IDE_CONFIG=serverName=squareone.tribe',
             'php-tests',
             'php',
-            '-dxdebug.remote_autostart=0',
-            '-dxdebug.remote_enable=0',
             '/application/www/vendor/bin/codecept',
             '-c',
             '/application/www/dev/tests',
@@ -36,12 +33,8 @@ class TestTest extends LocalDockerCommand {
             'exec',
             '--env',
             'COMPOSE_INTERACTIVE_NO_CLI=1',
-            '--env',
-            'PHP_IDE_CONFIG=serverName=squareone.tribe',
             'php-tests',
             'php',
-            '-dxdebug.remote_autostart=0',
-            '-dxdebug.remote_enable=0',
             '/application/www/vendor/bin/codecept',
             '-c',
             '/application/www/dev/tests',
@@ -75,12 +68,11 @@ class TestTest extends LocalDockerCommand {
             'COMPOSE_INTERACTIVE_NO_CLI=1',
             '--env',
             'PHP_IDE_CONFIG=serverName=squareone.tribe',
+            '--env',
+            BaseCommand::XDEBUG_ENV,
             '-T',
             'php-fpm',
             'php',
-            '-dxdebug.remote_autostart=1',
-            '-dxdebug.remote_host=host.tribe',
-            '-dxdebug.remote_enable=1',
             '/application/www/vendor/bin/codecept',
             '-c',
             '/application/www/dev/tests',
@@ -95,12 +87,11 @@ class TestTest extends LocalDockerCommand {
             'COMPOSE_INTERACTIVE_NO_CLI=1',
             '--env',
             'PHP_IDE_CONFIG=serverName=squareone.tribe',
+            '--env',
+            BaseCommand::XDEBUG_ENV,
             '-T',
             'php-fpm',
             'php',
-            '-dxdebug.remote_autostart=1',
-            '-dxdebug.remote_host=host.tribe',
-            '-dxdebug.remote_enable=1',
             '/application/www/vendor/bin/codecept',
             '-c',
             '/application/www/dev/tests',

--- a/tests/Feature/Commands/LocalDocker/TestTest.php
+++ b/tests/Feature/Commands/LocalDocker/TestTest.php
@@ -6,12 +6,14 @@ use App\Commands\BaseCommand;
 use App\Commands\DockerCompose;
 use App\Commands\LocalDocker\Test;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Storage;
 
 class TestTest extends LocalDockerCommand {
 
     public function test_it_calls_local_test_command() {
         $this->config->shouldReceive( 'getProjectName' )->andReturn( $this->project );
         $this->config->shouldReceive( 'getDockerDir' )->andReturn( $this->dockerDir );
+        $this->config->shouldReceive( 'getPhpIni' )->andReturn( storage_path( 'tests/dev/docker/php/php-ini-overrides.ini' ) );
 
         $this->dockerCompose->shouldReceive( 'call' )->with( DockerCompose::class, [
             '--project-name',
@@ -57,8 +59,11 @@ class TestTest extends LocalDockerCommand {
     }
 
     public function test_it_calls_local_test_command_with_options() {
+        Storage::disk( 'local' )->put( 'tests/dev/docker/php/php-ini-overrides.ini', 'xdebug.mode=debug,profile,trace' );
+
         $this->config->shouldReceive( 'getProjectName' )->andReturn( $this->project );
         $this->config->shouldReceive( 'getDockerDir' )->andReturn( $this->dockerDir );
+        $this->config->shouldReceive( 'getPhpIni' )->andReturn( storage_path( 'tests/dev/docker/php/php-ini-overrides.ini' ) );
 
         $this->dockerCompose->shouldReceive( 'call' )->with( DockerCompose::class, [
             '--project-name',
@@ -114,6 +119,71 @@ class TestTest extends LocalDockerCommand {
         ] );
 
         $this->assertSame( 0, $tester->getStatusCode() );
+        $this->assertStringNotContainsString( 'not configured correctly for xdebug v3.0', $tester->getDisplay() );
+    }
+
+    public function test_it_warns_the_user_if_xdebug_is_not_correctly_configured() {
+        Storage::disk( 'local' )->put( 'tests/dev/docker/php/php-ini-overrides.ini', 'xdebug.remote_enabled=1' );
+
+        $this->config->shouldReceive( 'getProjectName' )->andReturn( $this->project );
+        $this->config->shouldReceive( 'getDockerDir' )->andReturn( $this->dockerDir );
+        $this->config->shouldReceive( 'getPhpIni' )->andReturn( storage_path( 'tests/dev/docker/php/php-ini-overrides.ini' ) );
+
+        $this->dockerCompose->shouldReceive( 'call' )->with( DockerCompose::class, [
+            '--project-name',
+            $this->project,
+            'exec',
+            '--env',
+            'COMPOSE_INTERACTIVE_NO_CLI=1',
+            '--env',
+            'PHP_IDE_CONFIG=serverName=squareone.tribe',
+            '--env',
+            BaseCommand::XDEBUG_ENV,
+            '-T',
+            'php-fpm',
+            'php',
+            '/application/www/vendor/bin/codecept',
+            '-c',
+            '/application/www/dev/tests',
+            'clean',
+        ] );
+
+        $this->dockerCompose->shouldReceive( 'call' )->with( DockerCompose::class, [
+            '--project-name',
+            $this->project,
+            'exec',
+            '--env',
+            'COMPOSE_INTERACTIVE_NO_CLI=1',
+            '--env',
+            'PHP_IDE_CONFIG=serverName=squareone.tribe',
+            '--env',
+            BaseCommand::XDEBUG_ENV,
+            '-T',
+            'php-fpm',
+            'php',
+            '/application/www/vendor/bin/codecept',
+            '-c',
+            '/application/www/dev/tests',
+            'run',
+            'integration',
+        ] );
+
+        Artisan::swap( $this->dockerCompose );
+
+        $command = $this->app->make( Test::class );
+
+        $tester = $this->runCommand( $command, [
+            '--xdebug'    => true,
+            '--container' => 'php-fpm',
+            '--notty'     => true,
+            'args'        => [
+                'run',
+                'integration',
+            ],
+        ] );
+
+        $this->assertSame( 0, $tester->getStatusCode() );
+        $this->assertStringContainsString( 'not configured correctly for xdebug v3.0', $tester->getDisplay() );
     }
 
 }

--- a/tests/Feature/Commands/LocalDocker/WpTest.php
+++ b/tests/Feature/Commands/LocalDocker/WpTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Commands\LocalDocker;
 
+use App\Commands\BaseCommand;
 use App\Commands\DockerCompose;
 use App\Commands\LocalDocker\Wp;
 use Illuminate\Support\Facades\Artisan;
@@ -51,12 +52,8 @@ class WpTest extends LocalDockerCommand {
             'exec',
             '-T',
             '--env',
-            'PHP_IDE_CONFIG=serverName=squareone.tribe',
+            BaseCommand::XDEBUG_ENV,
             'php-fpm',
-            'php',
-            '-dxdebug.remote_autostart=1',
-            '-dxdebug.remote_host=host.tribe',
-            '-dxdebug.remote_enable=1',
             '/usr/local/bin/wp',
             '--allow-root',
             'option',

--- a/tests/Feature/Commands/LocalDocker/WpTest.php
+++ b/tests/Feature/Commands/LocalDocker/WpTest.php
@@ -6,6 +6,7 @@ use App\Commands\BaseCommand;
 use App\Commands\DockerCompose;
 use App\Commands\LocalDocker\Wp;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Storage;
 
 class WpTest extends LocalDockerCommand {
 
@@ -43,8 +44,11 @@ class WpTest extends LocalDockerCommand {
     }
 
     public function test_it_calls_local_wp_command_with_options() {
+        Storage::disk( 'local' )->put( 'tests/dev/docker/php/php-ini-overrides.ini', 'xdebug.mode=debug,profile,trace' );
+
         $this->config->shouldReceive( 'getProjectName' )->andReturn( $this->project );
         $this->config->shouldReceive( 'getDockerDir' )->andReturn( $this->dockerDir );
+        $this->config->shouldReceive( 'getPhpIni' )->andReturn( storage_path( 'tests/dev/docker/php/php-ini-overrides.ini' ) );
 
         $this->dockerCompose->shouldReceive( 'call' )->with( DockerCompose::class, [
             '--project-name',
@@ -76,6 +80,47 @@ class WpTest extends LocalDockerCommand {
         ] );
 
         $this->assertSame( 0, $tester->getStatusCode() );
+        $this->assertStringNotContainsString( 'not configured correctly for xdebug v3.0', $tester->getDisplay() );
+    }
+
+    public function test_it_warns_the_user_if_xdebug_is_not_correctly_configured() {
+        Storage::disk( 'local' )->put( 'tests/dev/docker/php/php-ini-overrides.ini', 'xdebug.remote_enabled=1' );
+
+        $this->config->shouldReceive( 'getProjectName' )->andReturn( $this->project );
+        $this->config->shouldReceive( 'getDockerDir' )->andReturn( $this->dockerDir );
+        $this->config->shouldReceive( 'getPhpIni' )->andReturn( storage_path( 'tests/dev/docker/php/php-ini-overrides.ini' ) );
+
+        $this->dockerCompose->shouldReceive( 'call' )->with( DockerCompose::class, [
+            '--project-name',
+            $this->project,
+            'exec',
+            '-T',
+            '--env',
+            BaseCommand::XDEBUG_ENV,
+            'php-fpm',
+            '/usr/local/bin/wp',
+            '--allow-root',
+            'option',
+            'get',
+            'home',
+        ] );
+
+        Artisan::swap( $this->dockerCompose );
+
+        $command = $this->app->make( Wp::class );
+
+        $tester = $this->runCommand( $command, [
+            '--notty'  => true,
+            '--xdebug' => true,
+            'args'     => [
+                'option',
+                'get',
+                'home',
+            ],
+        ] );
+
+        $this->assertSame( 0, $tester->getStatusCode() );
+        $this->assertStringContainsString( 'not configured correctly for xdebug v3.0', $tester->getDisplay() );
     }
 
 }

--- a/tests/Unit/Services/Docker/Local/ConfigTest.php
+++ b/tests/Unit/Services/Docker/Local/ConfigTest.php
@@ -134,4 +134,15 @@ class ConfigTest extends TestCase {
         $this->assertSame( storage_path( 'tests/squareone/dev/docker/composer' ), $root );
     }
 
+    public function test_it_gets_a_php_ini_path() {
+        $config = new Config( $this->runner );
+
+        // Mock getcwd() found our tests storage path
+        PHPMockery::mock( 'App\Services\Docker\Local', 'getcwd' )->andReturn( storage_path( 'tests/squareone' ) );
+
+        $phpIni = $config->getPhpIni();
+
+        $this->assertSame( storage_path( 'tests/squareone/dev/docker/php/php-ini-overrides.ini' ), $phpIni );
+    }
+
 }

--- a/tests/Unit/Services/XdebugValidatorTest.php
+++ b/tests/Unit/Services/XdebugValidatorTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use Tests\TestCase;
+use App\Services\FileIO;
+use App\Services\XdebugValidator;
+
+class XdebugValidatorTest extends TestCase {
+
+    private $file;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        $this->file = $this->mock( FileIO::class );
+    }
+
+    public function test_it_finds_a_valid_php_ini_file() {
+        $path      = storage_path( 'tests/dev/docker/php/php-ini-overrides.ini' );
+        $validator = new XdebugValidator( $this->file );
+
+        $this->file->expects( 'exists' )->once()->with( $path )->andReturnTrue();
+        $this->file->expects( 'contains' )->once()->with( $path, 'xdebug.mode' )->andReturnTrue();
+
+        $this->assertTrue( $validator->valid( $path ) );
+    }
+
+    public function test_it_returns_true_if_old_squareone_project() {
+        $path      = storage_path( 'tests/dev/docker/php/php-ini-overrides.ini' );
+        $validator = new XdebugValidator( $this->file );
+
+        $this->file->expects( 'exists' )->once()->with( $path )->andReturnFalse();
+
+        $this->assertTrue( $validator->valid( $path ) );
+    }
+
+    public function test_it_find_invalid_php_ini_configuration() {
+        $path      = storage_path( 'tests/dev/docker/php/php-ini-overrides.ini' );
+        $validator = new XdebugValidator( $this->file );
+
+        $this->file->expects( 'exists' )->once()->with( $path )->andReturnTrue();
+        $this->file->expects( 'contains' )->once()->with( $path, 'xdebug.mode' )->andReturnFalse();
+
+        $this->assertFalse( $validator->valid( $path ) );
+    }
+
+}

--- a/tests/Unit/Services/XdebugValidatorTest.php
+++ b/tests/Unit/Services/XdebugValidatorTest.php
@@ -9,40 +9,39 @@ use App\Services\XdebugValidator;
 class XdebugValidatorTest extends TestCase {
 
     private $file;
+    private $path;
 
     protected function setUp(): void {
         parent::setUp();
 
         $this->file = $this->mock( FileIO::class );
+        $this->path = storage_path( 'tests/dev/docker/php/php-ini-overrides.ini' );
     }
 
     public function test_it_finds_a_valid_php_ini_file() {
-        $path      = storage_path( 'tests/dev/docker/php/php-ini-overrides.ini' );
         $validator = new XdebugValidator( $this->file );
 
-        $this->file->expects( 'exists' )->once()->with( $path )->andReturnTrue();
-        $this->file->expects( 'contains' )->once()->with( $path, 'xdebug.mode' )->andReturnTrue();
+        $this->file->expects( 'exists' )->once()->with( $this->path )->andReturnTrue();
+        $this->file->expects( 'contains' )->once()->with( $this->path, 'xdebug.mode' )->andReturnTrue();
 
-        $this->assertTrue( $validator->valid( $path ) );
+        $this->assertTrue( $validator->valid( $this->path ) );
     }
 
     public function test_it_returns_true_if_old_squareone_project() {
-        $path      = storage_path( 'tests/dev/docker/php/php-ini-overrides.ini' );
         $validator = new XdebugValidator( $this->file );
 
-        $this->file->expects( 'exists' )->once()->with( $path )->andReturnFalse();
+        $this->file->expects( 'exists' )->once()->with( $this->path )->andReturnFalse();
 
-        $this->assertTrue( $validator->valid( $path ) );
+        $this->assertTrue( $validator->valid( $this->path ) );
     }
 
     public function test_it_find_invalid_php_ini_configuration() {
-        $path      = storage_path( 'tests/dev/docker/php/php-ini-overrides.ini' );
         $validator = new XdebugValidator( $this->file );
 
-        $this->file->expects( 'exists' )->once()->with( $path )->andReturnTrue();
-        $this->file->expects( 'contains' )->once()->with( $path, 'xdebug.mode' )->andReturnFalse();
+        $this->file->expects( 'exists' )->once()->with( $this->path )->andReturnTrue();
+        $this->file->expects( 'contains' )->once()->with( $this->path, 'xdebug.mode' )->andReturnFalse();
 
-        $this->assertFalse( $validator->valid( $path ) );
+        $this->assertFalse( $validator->valid( $this->path ) );
     }
 
 }

--- a/tests/Unit/Services/XdebugValidatorTest.php
+++ b/tests/Unit/Services/XdebugValidatorTest.php
@@ -35,7 +35,7 @@ class XdebugValidatorTest extends TestCase {
         $this->assertTrue( $validator->valid( $this->path ) );
     }
 
-    public function test_it_find_invalid_php_ini_configuration() {
+    public function test_it_finds_invalid_php_ini_configuration() {
         $validator = new XdebugValidator( $this->file );
 
         $this->file->expects( 'exists' )->once()->with( $this->path )->andReturnTrue();


### PR DESCRIPTION
- Removes Xdebug 2.x support
- Adds Xdebug 3.0+ support
- Warns the user if their project is out of date, and points them to the instructions to update it to get Xdebug working.

Targeted release: **5.0.0**