### PR TITLE
Bugfix/5.2.1/phpmyadmin and update note

### DIFF
--- a/app/Commands/GlobalDocker/MyAdmin.php
+++ b/app/Commands/GlobalDocker/MyAdmin.php
@@ -42,7 +42,7 @@ class MyAdmin extends BaseCommand {
         $start = $runner->run( 'docker start tribe-phpmyadmin' );
 
         if ( ! $start->ok() ) {
-            $run = $runner->run( $this->getRunCommand() );
+            $run = $runner->tty( true )->run( $this->getRunCommand() );
 
             if ( ! $run->ok() ) {
                 $runner->run( 'docker rm /tribe-phpmyadmin' );
@@ -61,7 +61,7 @@ class MyAdmin extends BaseCommand {
      * @return string
      */
     protected function getRunCommand(): string {
-        return 'docker run --name tribe-phpmyadmin --link tribe-mysql:db --network="global_proxy" -p 8080:80 phpmyadmin/phpmyadmin';
+        return 'docker run -d --name tribe-phpmyadmin --link tribe-mysql:db --network="global_proxy" -p 8080:80 phpmyadmin/phpmyadmin';
     }
 
 }

--- a/app/Commands/Self/UpdateCheck.php
+++ b/app/Commands/Self/UpdateCheck.php
@@ -101,6 +101,8 @@ class UpdateCheck extends Command {
                     sprintf( self::RELEASES_URL, $release->version ),
                 )
             );
+
+            $this->info( 'Note: this check is cached. Run "so self:update-check --force" to see if a newer version is available' );
         } elseif ( ! $this->option( 'only-new' ) ) {
             $this->info( sprintf( "You're running the latest version: %s", $this->version ) );
         }

--- a/app/Commands/Self/UpdateCheck.php
+++ b/app/Commands/Self/UpdateCheck.php
@@ -3,6 +3,7 @@
 namespace App\Commands\Self;
 
 use App\Services\Config\Github;
+use Carbon\Carbon;
 use Composer\Semver\Comparator;
 use App\Services\Update\Updater;
 use LaravelZero\Framework\Commands\Command;
@@ -102,7 +103,13 @@ class UpdateCheck extends Command {
                 )
             );
 
-            $this->info( 'Note: this check is cached. Run "so self:update-check --force" to see if a newer version is available' );
+            if ( ! $this->option( 'force' ) ) {
+                $this->info( 'Note: this check is cached. Run "so self:update-check --force" to see if a newer version is available' );
+                $this->info( sprintf(
+                    'Cache last updated: %s',
+                    Carbon::createFromDate( $release->updatedAt() )->diffForHumans()
+                ) );
+            }
         } elseif ( ! $this->option( 'only-new' ) ) {
             $this->info( sprintf( "You're running the latest version: %s", $this->version ) );
         }

--- a/tests/Feature/Commands/GlobalDocker/MyAdminTest.php
+++ b/tests/Feature/Commands/GlobalDocker/MyAdminTest.php
@@ -37,9 +37,14 @@ class MyAdminTest extends BaseCommandTester {
                ->with( 'docker rm /tribe-phpmyadmin' )
                ->andReturn( $this->runner );
 
+        $this->runner->shouldReceive( 'tty' )
+                     ->once()
+                     ->with( true )
+                     ->andReturn( $this->runner );
+
         $this->runner->shouldReceive( 'run' )
                ->twice()
-               ->with( 'docker run --name tribe-phpmyadmin --link tribe-mysql:db --network="global_proxy" -p 8080:80 phpmyadmin/phpmyadmin' )
+               ->with( 'docker run -d --name tribe-phpmyadmin --link tribe-mysql:db --network="global_proxy" -p 8080:80 phpmyadmin/phpmyadmin' )
                ->andReturn( $this->runner );
 
         $open = $this->mock( Open::class );

--- a/tests/Feature/Commands/Self/UpdateCheckTest.php
+++ b/tests/Feature/Commands/Self/UpdateCheckTest.php
@@ -26,6 +26,10 @@ class UpdateCheckTest extends BaseCommandTester {
     public function test_it_can_find_a_new_cached_version() {
         $this->release->shouldReceive( 'updatedAt' )->once()->andReturn( date( 'U' ) );
 
+        // Fake we ran --force 5 minutes ago.
+        $fiveMinutes = date( 'Y-m-d H:i:s', strtotime( '-5 minutes' ) );
+        $this->release->shouldReceive( 'updatedAt' )->once()->andReturn( $fiveMinutes );
+
         $this->release->version = '5000.0.0';
 
         $this->updater->shouldReceive( 'getCachedRelease' )->once()->andReturn( $this->release );
@@ -38,7 +42,8 @@ class UpdateCheckTest extends BaseCommandTester {
             'A new version "5000.0.0" is available! run "so self:update" to update now. See what\'s new: https://github.com/moderntribe/square1-global-docker/releases/tag/5000.0.0',
             $tester->getDisplay()
         );
-        $this->assertStringContainsString( '"so self:update-check --force"', $tester->getDisplay() );
+        $this->assertStringContainsString( 'so self:update-check --force', $tester->getDisplay() );
+        $this->assertStringContainsString( 'Cache last updated: 5 minutes ago', $tester->getDisplay() );
     }
 
     public function test_it_does_not_find_an_update() {
@@ -75,6 +80,8 @@ class UpdateCheckTest extends BaseCommandTester {
             'A new version "5000.0.0" is available! run "so self:update" to update now. See what\'s new: https://github.com/moderntribe/square1-global-docker/releases/tag/5000.0.0',
             $tester->getDisplay()
         );
+
+        $this->assertStringNotContainsString( 'so self:update-check --force', $tester->getDisplay() );
     }
 
     public function test_it_can_handle_empty_release_with_no_default_token() {

--- a/tests/Feature/Commands/Self/UpdateCheckTest.php
+++ b/tests/Feature/Commands/Self/UpdateCheckTest.php
@@ -34,11 +34,11 @@ class UpdateCheckTest extends BaseCommandTester {
         $tester  = $this->runCommand( $command, [] );
 
         $this->assertSame( 0, $tester->getStatusCode() );
-        $this->assertEquals(
+        $this->assertStringContainsString(
             'A new version "5000.0.0" is available! run "so self:update" to update now. See what\'s new: https://github.com/moderntribe/square1-global-docker/releases/tag/5000.0.0',
-            trim( $tester->getDisplay()
-            )
+            $tester->getDisplay()
         );
+        $this->assertStringContainsString( '"so self:update-check --force"', $tester->getDisplay() );
     }
 
     public function test_it_does_not_find_an_update() {
@@ -71,10 +71,9 @@ class UpdateCheckTest extends BaseCommandTester {
 
         $this->assertSame( 0, $tester->getStatusCode() );
 
-        $this->assertEquals(
+        $this->assertStringContainsString(
             'A new version "5000.0.0" is available! run "so self:update" to update now. See what\'s new: https://github.com/moderntribe/square1-global-docker/releases/tag/5000.0.0',
-            trim( $tester->getDisplay()
-            )
+            $tester->getDisplay()
         );
     }
 


### PR DESCRIPTION
A few more bug fixes for the 5.2.1 release:

- [FIXED]: https://github.com/moderntribe/square1-global-docker/issues/78 by letting the user know this request is cached, and showing them the cache time.
- [FIXED]: `so global:myadmin` properly runs the container in the background and displays the container download output if the user doesn't have it on their systems.