### PR TITLE
Loop bootstrap validation until it passes

### DIFF
--- a/app/Commands/LocalDocker/Bootstrap.php
+++ b/app/Commands/LocalDocker/Bootstrap.php
@@ -44,34 +44,40 @@ class Bootstrap extends BaseLocalDocker {
 
         $this->info( 'Alright, let\'s get ready to configure WordPress!' );
 
-        $email                = $this->ask( 'Enter your email address' );
-        $username             = $this->ask( 'Enter your admin username' );
-        $password             = $this->secret( 'Enter your password' );
-        $passwordConfirmation = $this->secret( 'Confirm your password' );
+        while ( true ) {
+            $email                = $this->ask( 'Enter your email address' );
+            $username             = $this->ask( 'Enter your admin username' );
+            $password             = $this->secret( 'Enter your password' );
+            $passwordConfirmation = $this->secret( 'Confirm your password' );
 
-        $validator = Validator::make( [
-            'email'                 => $email,
-            'username'              => $username,
-            'password'              => $password,
-            'password_confirmation' => $passwordConfirmation,
-        ], [
-            'email'                 => [ 'required', 'email' ],
-            'username'              => [ 'required' ],
-            'password'              => [ 'required', 'same:password_confirmation' ],
-            'password_confirmation' => [ 'required' ],
-        ], [
-            'required' => 'The :attribute field is required',
-            'same'     => 'The :attribute and :other must match',
-            'email'    => 'Invalid email address',
-        ] );
+            $validator = Validator::make( [
+                'email'                 => $email,
+                'username'              => $username,
+                'password'              => $password,
+                'password_confirmation' => $passwordConfirmation,
+            ], [
+                'email'                 => [ 'required', 'email' ],
+                'username'              => [ 'required' ],
+                'password'              => [ 'required', 'same:password_confirmation' ],
+                'password_confirmation' => [ 'required' ],
+            ], [
+                'required' => 'The :attribute field is required',
+                'same'     => 'The :attribute and :other must match',
+                'email'    => 'Invalid email address',
+            ] );
 
-        if ( $validator->fails() ) {
-
-            foreach ( $validator->errors()->all() as $error ) {
-                $this->error( $error );
+            if ( ! $validator->fails() ) {
+                break;
             }
 
-            return self::EXIT_ERROR;
+            $this->error( 'The following errors occurred, please try again: ' );
+
+            $count = 1;
+
+            foreach ( $validator->errors()->all() as $error ) {
+                $this->error( sprintf( '%d. %s', $count, $error  ) );
+                $count++;
+            }
         }
 
         $bootstrapper->renameObjectCache( $config->getProjectRoot() );

--- a/tests/Feature/Commands/LocalDocker/BootstrapTest.php
+++ b/tests/Feature/Commands/LocalDocker/BootstrapTest.php
@@ -17,8 +17,7 @@ use App\Commands\GlobalDocker\Start as GlobalStart;
 use Mockery;
 use Symfony\Component\Console\Exception\MissingInputException;
 
-
-class BootstrapTest extends LocalDockerCommand {
+final class BootstrapTest extends LocalDockerCommand {
 
     private $artisan;
     private $runner;


### PR DESCRIPTION
- [FIXED]:  https://github.com/moderntribe/square1-global-docker/issues/76 -`so bootstrap` will no longer hard exit and loop until validation properly passes.