### PR TITLE
Replace bash only here-string when creating databases

### DIFF
--- a/app/Services/ProjectBootstrapper.php
+++ b/app/Services/ProjectBootstrapper.php
@@ -121,13 +121,13 @@ class ProjectBootstrapper {
 
         // Create the WordPress database
         $this->runner->run( sprintf(
-            'docker exec -i tribe-mysql mysql -uroot -ppassword <<< "CREATE DATABASE tribe_%s;"',
+            'docker exec -i tribe-mysql mysql -uroot -ppassword -e "CREATE DATABASE tribe_%s;"',
             $projectName
         ) );
 
         // Create test databases
         $this->runner->run( sprintf(
-            'docker exec -i tribe-mysql mysql -uroot -ppassword <<< "CREATE DATABASE tribe_%s_tests; CREATE DATABASE tribe_%s_acceptance;"',
+            'docker exec -i tribe-mysql mysql -uroot -ppassword -e "CREATE DATABASE tribe_%s_tests; CREATE DATABASE tribe_%s_acceptance;"',
             $projectName,
             $projectName
         ) )->throw();

--- a/tests/Feature/Commands/LocalDocker/BootstrapTest.php
+++ b/tests/Feature/Commands/LocalDocker/BootstrapTest.php
@@ -71,12 +71,12 @@ class BootstrapTest extends LocalDockerCommand {
 
         $this->runner->shouldReceive( 'run' )
                      ->once()
-                     ->with( 'docker exec -i tribe-mysql mysql -uroot -ppassword <<< "CREATE DATABASE tribe_squareone;"' )
+                     ->with( 'docker exec -i tribe-mysql mysql -uroot -ppassword -e "CREATE DATABASE tribe_squareone;"' )
                      ->andReturnSelf();
 
         $this->runner->shouldReceive( 'run' )
                      ->once()
-                     ->with( 'docker exec -i tribe-mysql mysql -uroot -ppassword <<< "CREATE DATABASE tribe_squareone_tests; CREATE DATABASE tribe_squareone_acceptance;"' )
+                     ->with( 'docker exec -i tribe-mysql mysql -uroot -ppassword -e "CREATE DATABASE tribe_squareone_tests; CREATE DATABASE tribe_squareone_acceptance;"' )
                      ->andReturnSelf();
 
         $this->artisan->shouldReceive( 'call' )
@@ -176,12 +176,12 @@ class BootstrapTest extends LocalDockerCommand {
 
         $this->runner->shouldReceive( 'run' )
                      ->once()
-                     ->with( 'docker exec -i tribe-mysql mysql -uroot -ppassword <<< "CREATE DATABASE tribe_squareone;"' )
+                     ->with( 'docker exec -i tribe-mysql mysql -uroot -ppassword -e "CREATE DATABASE tribe_squareone;"' )
                      ->andReturnSelf();
 
         $this->runner->shouldReceive( 'run' )
                      ->once()
-                     ->with( 'docker exec -i tribe-mysql mysql -uroot -ppassword <<< "CREATE DATABASE tribe_squareone_tests; CREATE DATABASE tribe_squareone_acceptance;"' )
+                     ->with( 'docker exec -i tribe-mysql mysql -uroot -ppassword -e "CREATE DATABASE tribe_squareone_tests; CREATE DATABASE tribe_squareone_acceptance;"' )
                      ->andReturnSelf();
 
         $this->artisan->shouldReceive( 'call' )

--- a/tests/Unit/Services/ProjectBootstrapperTest.php
+++ b/tests/Unit/Services/ProjectBootstrapperTest.php
@@ -80,12 +80,12 @@ class ProjectBootstrapperTest extends TestCase {
         $projectName = 'squareone';
         $this->runner->shouldReceive( 'run' )
                      ->once()
-                     ->with( 'docker exec -i tribe-mysql mysql -uroot -ppassword <<< "CREATE DATABASE tribe_squareone;"' )
+                     ->with( 'docker exec -i tribe-mysql mysql -uroot -ppassword -e "CREATE DATABASE tribe_squareone;"' )
                      ->andReturnSelf();
 
         $this->runner->shouldReceive( 'run' )
                      ->once()
-                     ->with( 'docker exec -i tribe-mysql mysql -uroot -ppassword <<< "CREATE DATABASE tribe_squareone_tests; CREATE DATABASE tribe_squareone_acceptance;"' )
+                     ->with( 'docker exec -i tribe-mysql mysql -uroot -ppassword -e "CREATE DATABASE tribe_squareone_tests; CREATE DATABASE tribe_squareone_acceptance;"' )
                      ->andReturnSelf();
 
         $this->runner->shouldReceive( 'throw' )->once()->andReturnSelf();


### PR DESCRIPTION
- [FIXED]: Removed the bash only `<<<` here-string and replace with `-e` for better shell support when creating tables in the MariaDB container during project creation/bootstrapping.