### PR TITLE
Issue/98/allow sharing non wp projects

### DIFF
--- a/squareone.autocompletion
+++ b/squareone.autocompletion
@@ -25,8 +25,16 @@ _so()
 
         case "$com" in
 
+            _complete)
+            opts="${opts} --shell --input --current --symfony"
+            ;;
+
             bootstrap)
             opts="${opts} --multisite"
+            ;;
+
+            completion)
+            opts="${opts} --debug"
             ;;
 
             composer)
@@ -35,6 +43,10 @@ _so()
 
             create)
             opts="${opts} --remote --no-bootstrap"
+            ;;
+
+            docker)
+            opts="${opts} "
             ;;
 
             docker-compose)
@@ -66,7 +78,7 @@ _so()
             ;;
 
             share)
-            opts="${opts} --content-dir"
+            opts="${opts} --content-dir --not-wordpress"
             ;;
 
             shell)
@@ -167,7 +179,7 @@ _so()
 
     # completing for a command
     if [[ $cur == $com ]]; then
-        coms="bootstrap composer create docker-compose help list logs migrate-domain open restart share shell start stop test wp xdebug config:compose-copy config:copy global:cert global:logs global:myadmin global:portainer global:restart global:start global:status global:stop global:stop-all schedule:finish schedule:run self:update self:update-check vendor:publish"
+        coms="_complete bootstrap completion composer create docker docker-compose help list logs migrate-domain open restart share shell start stop test wp xdebug config:compose-copy config:copy global:cert global:logs global:myadmin global:portainer global:restart global:start global:status global:stop global:stop-all schedule:finish schedule:run self:update self:update-check vendor:publish"
 
         COMPREPLY=($(compgen -W "${coms}" -- ${cur}))
         __ltrim_colon_completions "$cur"

--- a/squareone.autocompletion.fish
+++ b/squareone.autocompletion.fish
@@ -1,6 +1,6 @@
 function __fish_so_no_subcommand
     for i in (commandline -opc)
-        if contains -- $i bootstrap composer create docker-compose help list logs migrate-domain open restart share shell start stop test wp xdebug config:compose-copy config:copy global:cert global:logs global:myadmin global:portainer global:restart global:start global:status global:stop global:stop-all schedule:finish schedule:run self:update self:update-check vendor:publish
+        if contains -- $i _complete bootstrap completion composer create docker docker-compose help list logs migrate-domain open restart share shell start stop test wp xdebug config:compose-copy config:copy global:cert global:logs global:myadmin global:portainer global:restart global:start global:status global:stop global:stop-all schedule:finish schedule:run self:update self:update-check vendor:publish
             return 1
         end
     end
@@ -18,9 +18,12 @@ complete -c so -n '__fish_so_no_subcommand' -l no-interaction -d 'Do not ask any
 complete -c so -n '__fish_so_no_subcommand' -l env -d 'The environment the command should run under'
 
 # commands
+complete -c so -f -n '__fish_so_no_subcommand' -a _complete -d 'Internal command to provide shell completion suggestions'
 complete -c so -f -n '__fish_so_no_subcommand' -a bootstrap -d 'Bootstrap WordPress: Install core, create an admin user'
+complete -c so -f -n '__fish_so_no_subcommand' -a completion -d 'Dump the shell completion script'
 complete -c so -f -n '__fish_so_no_subcommand' -a composer -d 'Run a composer command in the local docker container'
 complete -c so -f -n '__fish_so_no_subcommand' -a create -d 'Create a new SquareOne project based off of the square-one framework'
+complete -c so -f -n '__fish_so_no_subcommand' -a docker -d 'Pass through for the docker binary'
 complete -c so -f -n '__fish_so_no_subcommand' -a docker-compose -d 'Pass through for docker-compose binary'
 complete -c so -f -n '__fish_so_no_subcommand' -a help -d 'Display help for a command'
 complete -c so -f -n '__fish_so_no_subcommand' -a list -d 'List commands'
@@ -32,7 +35,7 @@ complete -c so -f -n '__fish_so_no_subcommand' -a share -d 'Share your local pro
 complete -c so -f -n '__fish_so_no_subcommand' -a shell -d 'Gives you a bash shell into the php-fpm docker container'
 complete -c so -f -n '__fish_so_no_subcommand' -a start -d 'Starts your local SquareOne project, run anywhere in a project folder'
 complete -c so -f -n '__fish_so_no_subcommand' -a stop -d 'Stops your local SquareOne project, run anywhere in a project folder'
-complete -c so -f -n '__fish_so_no_subcommand' -a test -d 'Run codeception tests in the SquareOne local container'
+complete -c so -f -n '__fish_so_no_subcommand' -a test -d 'Run codeception tests in the SquareOne php container'
 complete -c so -f -n '__fish_so_no_subcommand' -a wp -d 'Run WP CLI commands in the SquareOne local container'
 complete -c so -f -n '__fish_so_no_subcommand' -a xdebug -d 'Enable/disable Xdebug in the php-fpm container to increase performance on MacOS'
 complete -c so -f -n '__fish_so_no_subcommand' -a config:compose-copy -d 'Copies the Global docker-compose.yml file to the local config folder for customization'
@@ -54,14 +57,25 @@ complete -c so -f -n '__fish_so_no_subcommand' -a vendor:publish -d 'Publish any
 
 # command options
 
+# _complete
+complete -c so -A -n '__fish_seen_subcommand_from _complete' -l shell -d 'The shell type ("bash")'
+complete -c so -A -n '__fish_seen_subcommand_from _complete' -l input -d 'An array of input tokens (e.g. COMP_WORDS or argv)'
+complete -c so -A -n '__fish_seen_subcommand_from _complete' -l current -d 'The index of the "input" array that the cursor is in (e.g. COMP_CWORD)'
+complete -c so -A -n '__fish_seen_subcommand_from _complete' -l symfony -d 'The version of the completion script'
+
 # bootstrap
 complete -c so -A -n '__fish_seen_subcommand_from bootstrap' -l multisite -d 'Bootstrap for a multisite project'
+
+# completion
+complete -c so -A -n '__fish_seen_subcommand_from completion' -l debug -d 'Tail the completion debug log'
 
 # composer
 
 # create
 complete -c so -A -n '__fish_seen_subcommand_from create' -l remote -d 'Sets a new git remote, e.g. https://github.com/moderntribe/$project/'
 complete -c so -A -n '__fish_seen_subcommand_from create' -l no-bootstrap -d 'Do not attempt to automatically configure the project'
+
+# docker
 
 # docker-compose
 
@@ -84,6 +98,7 @@ complete -c so -A -n '__fish_seen_subcommand_from list' -l short -d 'To skip des
 
 # share
 complete -c so -A -n '__fish_seen_subcommand_from share' -l content-dir -d 'The name of the wp-content directory, if renamed'
+complete -c so -A -n '__fish_seen_subcommand_from share' -l not-wordpress -d 'Attempt to share a non-WordPress project'
 
 # shell
 complete -c so -A -n '__fish_seen_subcommand_from shell' -l user -d 'The username or UID of the account to use'

--- a/squareone.autocompletion.zsh
+++ b/squareone.autocompletion.zsh
@@ -19,7 +19,7 @@ _so()
         opts=("--help:Display help for the given command. When no command is given display help for the <info\>list</info\> command" "--quiet:Do not output any message" "--verbose:Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug" "--version:Display this application version" "--ansi:Force \(or disable --no-ansi\) ANSI output" "--no-ansi:Negate the "--ansi" option" "--no-interaction:Do not ask any interactive question" "--env:The environment the command should run under")
     elif [[ $cur == $com ]]; then
         state="command"
-        coms=("bootstrap:Bootstrap WordPress: Install core, create an admin user" "composer:Run a composer command in the local docker container" "create:Create a new SquareOne project based off of the square-one framework" "docker-compose:Pass through for docker-compose binary" "help:Display help for a command" "list:List commands" "logs:Displays local SquareOne project docker logs" "migrate-domain:Migrate a recently imported remote database to your local\; Automatically detects the domain name." "open:Open\'s a URL in your default browser or the current SquareOne project" "restart:Restarts your local SquareOne project" "share:Share your local project on a temporary URL using ngrok" "shell:Gives you a bash shell into the php-fpm docker container" "start:Starts your local SquareOne project, run anywhere in a project folder" "stop:Stops your local SquareOne project, run anywhere in a project folder" "test:Run codeception tests in the SquareOne local container" "wp:Run WP CLI commands in the SquareOne local container" "xdebug:Enable/disable Xdebug in the php-fpm container to increase performance on MacOS" "config\:compose-copy:Copies the Global docker-compose.yml file to the local config folder for customization" "config\:copy:Copies the squareone.yml file to the local config folder for customization" "global\:cert:Manually generate a certificate for a local domain" "global\:logs:Displays SquareOne global docker logs" "global\:myadmin:Starts a phpMyAdmin container" "global\:portainer:Launches Portainer docker management" "global\:restart:Restarts the SquareOne global docker containers" "global\:start:Starts the SquareOne global docker containers" "global\:status:Shows all running docker containers" "global\:stop:Stops the SquareOne global docker containers" "global\:stop-all:Stops all running docker containers" "schedule\:finish:Handle the completion of a scheduled command" "schedule\:run:Run the scheduled commands" "self\:update:Updates the application, if available" "self\:update-check:Check if there is an updated release" "vendor\:publish:Publish any publishable assets from vendor packages")
+        coms=("_complete:Internal command to provide shell completion suggestions" "bootstrap:Bootstrap WordPress: Install core, create an admin user" "completion:Dump the shell completion script" "composer:Run a composer command in the local docker container" "create:Create a new SquareOne project based off of the square-one framework" "docker:Pass through for the docker binary" "docker-compose:Pass through for docker-compose binary" "help:Display help for a command" "list:List commands" "logs:Displays local SquareOne project docker logs" "migrate-domain:Migrate a recently imported remote database to your local\; Automatically detects the domain name." "open:Open\'s a URL in your default browser or the current SquareOne project" "restart:Restarts your local SquareOne project" "share:Share your local project on a temporary URL using ngrok" "shell:Gives you a bash shell into the php-fpm docker container" "start:Starts your local SquareOne project, run anywhere in a project folder" "stop:Stops your local SquareOne project, run anywhere in a project folder" "test:Run codeception tests in the SquareOne php container" "wp:Run WP CLI commands in the SquareOne local container" "xdebug:Enable/disable Xdebug in the php-fpm container to increase performance on MacOS" "config\:compose-copy:Copies the Global docker-compose.yml file to the local config folder for customization" "config\:copy:Copies the squareone.yml file to the local config folder for customization" "global\:cert:Manually generate a certificate for a local domain" "global\:logs:Displays SquareOne global docker logs" "global\:myadmin:Starts a phpMyAdmin container" "global\:portainer:Launches Portainer docker management" "global\:restart:Restarts the SquareOne global docker containers" "global\:start:Starts the SquareOne global docker containers" "global\:status:Shows all running docker containers" "global\:stop:Stops the SquareOne global docker containers" "global\:stop-all:Stops all running docker containers" "schedule\:finish:Handle the completion of a scheduled command" "schedule\:run:Run the scheduled commands" "self\:update:Updates the application, if available" "self\:update-check:Check if there is an updated release" "vendor\:publish:Publish any publishable assets from vendor packages")
     fi
 
     case $state in
@@ -29,8 +29,16 @@ _so()
         option)
             case "$com" in
 
+            _complete)
+            opts+=("--shell:The shell type \("bash"\)" "--input:An array of input tokens \(e.g. COMP_WORDS or argv\)" "--current:The index of the "input" array that the cursor is in \(e.g. COMP_CWORD\)" "--symfony:The version of the completion script")
+            ;;
+
             bootstrap)
             opts+=("--multisite:Bootstrap for a multisite project")
+            ;;
+
+            completion)
+            opts+=("--debug:Tail the completion debug log")
             ;;
 
             composer)
@@ -39,6 +47,10 @@ _so()
 
             create)
             opts+=("--remote:Sets a new git remote, e.g. https://github.com/moderntribe/\$project/" "--no-bootstrap:Do not attempt to automatically configure the project")
+            ;;
+
+            docker)
+            opts+=()
             ;;
 
             docker-compose)
@@ -70,7 +82,7 @@ _so()
             ;;
 
             share)
-            opts+=("--content-dir:The name of the wp-content directory, if renamed")
+            opts+=("--content-dir:The name of the wp-content directory, if renamed" "--not-wordpress:Attempt to share a non-WordPress project")
             ;;
 
             shell)


### PR DESCRIPTION
- Fixes https://github.com/moderntribe/square1-global-docker/issues/98
- Adds `so share --not-wordpress` or `so share -N` to bypass checking for/copying the mu-plugin that creates relative links for non-WordPress projects. This isn't guaranteed to actually work, but just allow the possibility of sharing other projects.