### PR TITLE
Issue/122/brew dependency updates

### DIFF
--- a/brew/packages.txt
+++ b/brew/packages.txt
@@ -1,7 +1,6 @@
-bash-completion@2
 composer
 coreutils
 curl
 docker-credential-helper
 git
-php@7.4
+php@8.0

--- a/install/install.sh
+++ b/install/install.sh
@@ -9,7 +9,7 @@ PHAR_NAME="so.phar"
 CONFIG_DIR=~/.config/squareone
 BIN_NAME="so"
 DC_VERSION="1.29.2"
-NVM_VERSION="0.38.0"
+NVM_VERSION="0.39.1"
 AUTOCOMPLETE_BASH="squareone.autocompletion"
 AUTOCOMPLETE_ZSH="squareone_completion.zsh"
 AUTOCOMPLETE_FISH="so.fish"
@@ -43,7 +43,6 @@ install_homebrew() {
 
 enable_autocomplete() {
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    sudo curl -fsSL 'https://raw.githubusercontent.com/moderntribe/square1-global-docker/master/squareone.autocompletion' -o "$(brew --prefix)/etc/bash_completion.d/${AUTOCOMPLETE_BASH}"
     curl -fsSL 'https://raw.githubusercontent.com/moderntribe/square1-global-docker/master/squareone.autocompletion.zsh' -o ~/."${AUTOCOMPLETE_ZSH}" && echo "source ~/.${AUTOCOMPLETE_ZSH}" >> ~/.zshrc
   else
     sudo curl -fsSL 'https://raw.githubusercontent.com/moderntribe/square1-global-docker/master/squareone.autocompletion' -o /etc/bash_completion.d/"${AUTOCOMPLETE_BASH}"
@@ -123,8 +122,8 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   echo "* Installing dependencies via brew..."
   curl -fsSL https://raw.githubusercontent.com/moderntribe/square1-global-docker/master/brew/packages.txt -o "${CONFIG_DIR}/packages.txt"
   brew install "$(<${CONFIG_DIR}/packages.txt)"
-  echo "* Setting the default PHP version to 7.4..."
-  brew link php@7.4 --force
+  echo "* Setting the default PHP version to 8.0..."
+  brew link php@8.0 --force
 fi
 
 # Debian Linux flavors including WSL2


### PR DESCRIPTION
- Fixes https://github.com/moderntribe/square1-global-docker/issues/122
- Updates brew dependencies, PHP7.4 > PHP8.0 as brew removed 7.4.
- Removes bash-completion from Mac installer, everyone is on ZSH anyways.
- Updates NVM to 0.39.1 in the installer.

@dpellenwood  If whomever was having problems with this can try this version of the installer before we merge, it should now work, let me know:

`bash -c "$(curl -fsSL https://raw.githubusercontent.com/moderntribe/square1-global-docker/issue/122/brew-dependency-updates/install/install.sh)"`