### PR TITLE
Use xargs to parse brew packages

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -121,7 +121,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 
   echo "* Installing dependencies via brew..."
   curl -fsSL https://raw.githubusercontent.com/moderntribe/square1-global-docker/master/brew/packages.txt -o "${CONFIG_DIR}/packages.txt"
-  brew install "$(<${CONFIG_DIR}/packages.txt)"
+  xargs brew install "${CONFIG_DIR}/packages.txt"
   echo "* Setting the default PHP version to 8.0..."
   brew link php@8.0 --force
 fi


### PR DESCRIPTION
- Should fix installer on OSX with Bash 5.1.x