### PR TITLE
Bugfix: big sur missing openssl

### DIFF
--- a/brew/packages.txt
+++ b/brew/packages.txt
@@ -3,4 +3,5 @@ coreutils
 curl
 docker-credential-helper
 git
+openssl
 php@8.0

--- a/install/install.sh
+++ b/install/install.sh
@@ -124,6 +124,8 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   xargs brew install < "${CONFIG_DIR}/packages.txt"
   echo "* Setting the default PHP version to 8.0..."
   brew link php@8.0 --force
+  echo "* Setting proper version of openssl..."
+  brew link openssl --force
 fi
 
 # Debian Linux flavors including WSL2


### PR DESCRIPTION
- Big Sur is missing openssl out of the box, install it and link it with brew. Users should reboot after the installer and it should read the correct version after that.