### PR TITLE
BUGFIX: Properly find local project squareone.yml configs 

### DIFF
--- a/app/Services/ConfigLocator.php
+++ b/app/Services/ConfigLocator.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace App\Services;
+
+use Symfony\Component\Config\FileLocator;
+use Throwable;
+
+class ConfigLocator {
+
+    /**
+     * Find a configuration file and traverse up the file system until we
+     * find one or reach the root.
+     *
+     * @param  string  $directory  The file system path to begin the search.
+     * @param  string  $filename   The file to search for.
+     *
+     * @return string
+     */
+    public function find( string $directory, string $filename = 'squareone.yml' ): string {
+        $found = '';
+
+        while ( true ) {
+            $locator = new FileLocator( $directory );
+
+            try {
+                $found = $locator->locate( $filename );
+            } catch ( Throwable $e ) {
+                $directory = dirname( $directory );
+            }
+
+            if ( $found || $directory === '/' ) {
+                return $found;
+            }
+        }
+    }
+
+}

--- a/tests/Feature/Services/ConfigLocatorTest.php
+++ b/tests/Feature/Services/ConfigLocatorTest.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Feature\Services;
+
+use App\Services\ConfigLocator;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+final class ConfigLocatorTest extends TestCase {
+
+    public function test_it_finds_a_config_file_in_the_project_root(): void {
+        Storage::disk( 'local' )->makeDirectory( 'tests/fakeproject' );
+        Storage::disk( 'local' )->put( 'tests/fakeproject/squareone.yml', '' );
+
+        $locator = new ConfigLocator();
+
+        $file = $locator->find( storage_path( 'tests/fakeproject' ) );
+
+        $this->assertSame( storage_path( 'tests/fakeproject/squareone.yml' ), $file );
+    }
+
+    public function test_it_finds_a_custom_config_file_in_the_project_root(): void {
+        Storage::disk( 'local' )->makeDirectory( 'tests/fakeproject' );
+        Storage::disk( 'local' )->put( 'tests/fakeproject/customconfig.yml', '' );
+
+        $locator = new ConfigLocator();
+
+        $file = $locator->find( storage_path( 'tests/fakeproject' ), 'customconfig.yml' );
+
+        $this->assertSame( storage_path( 'tests/fakeproject/customconfig.yml' ), $file );
+    }
+
+    public function test_it_finds_a_config_file_from_project_sub_folders(): void {
+        Storage::disk( 'local' )->makeDirectory( 'tests/newfakeproject/some/sub/folder' );
+        Storage::disk( 'local' )->put( 'tests/newfakeproject/squareone.yml', '' );
+
+        $locator = new ConfigLocator();
+
+        $file = $locator->find( storage_path( 'tests/newfakeproject/some/sub/folder' ) );
+
+        $this->assertSame( storage_path( 'tests/newfakeproject/squareone.yml' ), $file );
+    }
+
+    public function test_it_finds_a_custom_config_file_from_project_sub_folders(): void {
+        Storage::disk( 'local' )->makeDirectory( 'tests/fakeproject/some/sub/folder' );
+        Storage::disk( 'local' )->put( 'tests/fakeproject/localconfig.yml', '' );
+
+        $locator = new ConfigLocator();
+
+        $file = $locator->find( storage_path( 'tests/fakeproject/some/sub/folder' ), 'localconfig.yml' );
+
+        $this->assertSame( storage_path( 'tests/fakeproject/localconfig.yml' ), $file );
+    }
+
+    public function test_it_does_not_find_a_config_file(): void {
+        $locator = new ConfigLocator();
+
+        $file = $locator->find( '/tmp' );
+
+        $this->assertSame( '', $file );
+    }
+
+}


### PR DESCRIPTION
Fixes a bug where if a `so` local docker command was called in a project's sub directory (aka not the root), any custom config would not be read.